### PR TITLE
confirm_destructive_query: Use confirm rather than prompt

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -129,6 +129,7 @@ Contributors:
     * Damien Baty (dbaty)
     * blag
     * Rob Berry (rob-b)
+    * Sharon Yogev (sharonyogev)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -32,6 +32,7 @@ Bug fixes:
   predetermined table aliases instead of generating aliases programmatically on
   the fly
 * Fixed SQL error when there is a comment on the first line: ([issue 1403](https://github.com/dbcli/pgcli/issues/1403))
+* Fix wrong usage of prompt instead of confirm when confirm execution of destructive query
 
 Internal:
 ---------

--- a/pgcli/packages/prompt_utils.py
+++ b/pgcli/packages/prompt_utils.py
@@ -16,9 +16,9 @@ def confirm_destructive_query(queries, keywords, alias):
     if alias:
         info += f" in {click.style(alias, fg='red')}"
 
-    prompt_text = f"{info}.\nDo you want to proceed? (y/n)"
+    prompt_text = f"{info}.\nDo you want to proceed?"
     if is_destructive(queries, keywords) and sys.stdin.isatty():
-        return prompt(prompt_text, type=bool)
+        return confirm(prompt_text)
 
 
 def confirm(*args, **kwargs):

--- a/tests/features/steps/basic_commands.py
+++ b/tests/features/steps/basic_commands.py
@@ -206,7 +206,7 @@ def step_resppond_to_destructive_command(context, response):
     """Respond to destructive command."""
     wrappers.expect_exact(
         context,
-        "You're about to run a destructive command.\r\nDo you want to proceed? (y/n):",
+        "You're about to run a destructive command.\r\nDo you want to proceed? [y/N]:",
         timeout=2,
     )
     context.cli.sendline(response.strip())

--- a/tests/features/steps/expanded.py
+++ b/tests/features/steps/expanded.py
@@ -16,7 +16,7 @@ def step_prepare_data(context):
     context.cli.sendline("drop table if exists a;")
     wrappers.expect_exact(
         context,
-        "You're about to run a destructive command.\r\nDo you want to proceed? (y/n):",
+        "You're about to run a destructive command.\r\nDo you want to proceed? [y/N]:",
         timeout=2,
     )
     context.cli.sendline("y")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
